### PR TITLE
add client-id flag

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,7 +35,7 @@ type Tracing struct {
 type GraphExplorer struct {
 	ClientID string
 	Issuer   string
-	GraphUrl string
+	GraphURL string
 }
 
 // Config combines all available configuration parts.

--- a/pkg/flagset/flagset.go
+++ b/pkg/flagset/flagset.go
@@ -135,11 +135,18 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			Destination: &cfg.GraphExplorer.Issuer,
 		},
 		&cli.StringFlag{
+			Name:        "client-id",
+			Value:       "graph_explorer",
+			Usage:       "Set the OpenID Client ID to send to the issuer",
+			EnvVar:      "GRAPH_EXPLORER_CLIENT_ID",
+			Destination: &cfg.GraphExplorer.ClientID,
+		},
+		&cli.StringFlag{
 			Name:        "graph-url",
 			Value:       "http://localhost:9120",
 			Usage:       "Set the url to the graph api service",
 			EnvVar:      "GRAPH_EXPLORER_GRAPH_URL",
-			Destination: &cfg.GraphExplorer.GraphUrl,
+			Destination: &cfg.GraphExplorer.GraphURL,
 		},
 	}
 }

--- a/pkg/service/v0/service.go
+++ b/pkg/service/v0/service.go
@@ -62,7 +62,7 @@ func (p GraphExplorer) ConfigJs(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	io.WriteString(w, fmt.Sprintf("window.ClientId = \"%v\";", p.config.GraphExplorer.ClientID))
 	io.WriteString(w, fmt.Sprintf("window.Iss = \"%v\";", p.config.GraphExplorer.Issuer))
-	io.WriteString(w, fmt.Sprintf("window.GraphUrl = \"%v\";", p.config.GraphExplorer.GraphUrl))
+	io.WriteString(w, fmt.Sprintf("window.GraphUrl = \"%v\";", p.config.GraphExplorer.GraphURL))
 }
 
 // Static simply serves all static files.


### PR DESCRIPTION
without this the client id cannot be set and defaults to `""`